### PR TITLE
Upgrade electron-packager to make icons works with Electron 0.37.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "archiver": "^0.14.4",
-    "electron-packager": "^5.0.1",
+    "electron-packager": "^6.0.0",
     "minimist": "^1.1.2"
   }
 }


### PR DESCRIPTION
electron 0.37.4 comes with some new stuff (filename changed for icons, etc ...) and some feature (icons for instance) doesn't work anymore when using `electron-zip-packager`. 
